### PR TITLE
import wordlist as constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,8 @@ use std::collections::HashSet;
 use itertools::Itertools;
 use rand::{Rng, OsRng};
 
-fn words() -> &'static [&'static str] {
-	lazy_static! {
-		static ref WORDS: Vec<&'static str> = include_str!("../res/wordlist.txt")
-			.lines()
-			.collect();
-	}
-  &WORDS
-}
+// the wordlist JSON also happens to be valid Rust syntax for an array constant.
+const WORDS: &'static [&'static str] = &include!("../res/wordlist.json");
 
 /// Generate a string which is a random phrase of a number of lowercase words.
 ///
@@ -43,9 +37,8 @@ fn words() -> &'static [&'static str] {
 /// 12 gives 155 bits of entropy (almost saturating address space); 20 gives 258 bits
 /// which is enough to saturate 32-byte key space
 pub fn random_phrase(no_of_words: usize) -> String {
-  let words = words();
 	let mut rng = OsRng::new().expect("Not able to operate without random source.");
-	(0..no_of_words).map(|_| rng.choose(words).unwrap()).join(" ")
+	(0..no_of_words).map(|_| rng.choose(WORDS).unwrap()).join(" ")
 }
 
 /// Phrase Validation Error
@@ -62,13 +55,13 @@ pub enum Error {
 /// 2. There are at least `expected_no_of_words` in the phrase.
 pub fn validate_phrase(phrase: &str, expected_no_of_words: usize) -> Result<(), Error> {
 	lazy_static! {
-    static ref WORDS: HashSet<&'static str> = words().iter().cloned().collect();
+    static ref WORD_SET: HashSet<&'static str> = WORDS.iter().cloned().collect();
   }
 
   let mut len = 0;
   for word in phrase.split_whitespace() {
     len += 1;
-    if !WORDS.contains(word) {
+    if !WORD_SET.contains(word) {
       return Err(Error::WordNotFromDictionary(word.into()));
     }
   }


### PR DESCRIPTION
Closes #4 

We could also remove `lazy_static` if we used something like `phf` to generate a perfect hash set for the wordlist at compile time.